### PR TITLE
[Feature/issue-051] 401발생 시 토큰 재발급 로직 구현

### DIFF
--- a/src/constants/language.ts
+++ b/src/constants/language.ts
@@ -1,0 +1,8 @@
+import type { LoginResponse } from '@/types/auth';
+import type { LanguageType } from '@/types/type';
+
+export const LANGUAGE: Record<LoginResponse['data']['language'], LanguageType> =
+  {
+    KOREAN: 'ko',
+    ENGLISH: 'en',
+  } as const;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -11,7 +11,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import type { ApiFailResponse } from '@/types/api';
 import type { AxiosError } from 'axios';
 import { setLanguage } from '@/lib/i18n';
-import type { LanguageType } from '@/types/type';
+import { LANGUAGE } from '@/constants/language';
 
 export const useAuthentication = () => {
   return useQuery<AuthenticationResponse, Error, AuthenticationResponse>({
@@ -36,7 +36,7 @@ export const useLogin = () => {
       try {
         const verifyResult = await authApi.verify();
         if (verifyResult.data.isTokenVerified) {
-          setLanguage(res.data.language as LanguageType);
+          setLanguage(LANGUAGE[res.data.language]);
           queryClient.setQueryData(['verify'], verifyResult);
           navigate(redirectPath);
         }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -7,14 +7,17 @@ import type {
   LogOutResponse,
 } from '@/types/auth';
 import { toast } from 'sonner';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import type { ApiFailResponse } from '@/types/api';
+import type { AxiosError } from 'axios';
+import { setLanguage } from '@/lib/i18n';
+import type { LanguageType } from '@/types/type';
 
 export const useAuthentication = () => {
   return useQuery<AuthenticationResponse, Error, AuthenticationResponse>({
-    queryKey: ['me'],
+    queryKey: ['verify'],
+    queryFn: authApi.verify,
     staleTime: Infinity,
-    queryFn: authApi.authentication,
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -23,19 +26,27 @@ export const useAuthentication = () => {
 export const useLogin = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [searchParam] = useSearchParams();
 
-  return useMutation<LoginResponse, ApiFailResponse, LoginRequest>({
+  const redirectPath = searchParam.get('redirect') || '/';
+
+  return useMutation<LoginResponse, AxiosError<ApiFailResponse>, LoginRequest>({
     mutationFn: (data) => authApi.login(data),
-    onSuccess: (res) => {
-      console.log(res.data.language);
-      queryClient.invalidateQueries({
-        queryKey: ['me'],
-      });
-      navigate('/');
+    onSuccess: async (res) => {
+      try {
+        const verifyResult = await authApi.verify();
+        if (verifyResult.data.isTokenVerified) {
+          setLanguage(res.data.language as LanguageType);
+          queryClient.setQueryData(['verify'], verifyResult);
+          navigate(redirectPath);
+        }
+      } catch {
+        toast.error('인증 실패');
+      }
     },
 
     onError: (error) => {
-      toast.error(error.message);
+      toast.error(error.response?.data.message);
     },
   });
 };

--- a/src/layout/ProtectedRouteLayout.tsx
+++ b/src/layout/ProtectedRouteLayout.tsx
@@ -1,32 +1,34 @@
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAuthentication } from '@/hooks/useAuth';
-import { Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 const ProtectedRouteLayout = () => {
-  const { error, isPending } = useAuthentication();
+  const { data, isPending, isError } = useAuthentication();
+  const location = useLocation();
+  const currentPath = location.pathname + location.search;
 
   if (isPending) {
     return null;
   }
 
-  if (error)
-    // return (
-    //   <Navigate
-    //     to='/onboarding'
-    //     replace
-    //   />
-    // );
-
+  if (isError || !data.data.isTokenVerified)
     return (
-      <div className='flex h-dvh w-dvw justify-center'>
-        <ScrollArea
-          className='h-dvh w-[360px]'
-          id='navigation-root'
-        >
-          <Outlet />
-        </ScrollArea>
-      </div>
+      <Navigate
+        to={`/login?redirect=${encodeURIComponent(currentPath)}`}
+        replace
+      />
     );
+
+  return (
+    <div className='flex h-dvh w-dvw justify-center'>
+      <ScrollArea
+        className='h-dvh w-[360px]'
+        id='navigation-root'
+      >
+        <Outlet />
+      </ScrollArea>
+    </div>
+  );
 };
 
 export default ProtectedRouteLayout;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import { authApi } from '@/services/authService';
+import axios, { type AxiosRequestConfig } from 'axios';
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL,
@@ -7,8 +8,26 @@ export const instance = axios.create({
 
 instance.interceptors.response.use(
   (response) => response,
-  (error: unknown) => {
+  async (error) => {
     if (axios.isAxiosError(error)) {
+      const originalRequest = error.config as AxiosRequestConfig & {
+        _retry?: boolean;
+      };
+
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+        try {
+          await authApi.tokenRefresh();
+          return instance(originalRequest);
+        } catch (refreshErr) {
+          alert('로그인이 만료되었습니다.');
+          await authApi.logout();
+          const currentPath = window.location.pathname + window.location.search;
+          window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+          return Promise.reject(refreshErr);
+        }
+      }
+
       return Promise.reject(error.response?.data);
     } else {
       return Promise.reject(new Error('알 수 없는 오류가 발생하였습니다.'));

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -7,7 +7,15 @@ export const instance = axios.create({
 });
 
 instance.interceptors.response.use(
-  (response) => response,
+  async (res) => {
+    const isVerifiedApi = res.config.url === '/api/v1/auth/verify';
+    if (isVerifiedApi && !res.data.data.isTokenVerified) {
+      const originalRequest = res.config;
+      await authApi.tokenRefresh();
+      return instance(originalRequest);
+    }
+    return res;
+  },
   async (error) => {
     if (axios.isAxiosError(error)) {
       const originalRequest = error.config as AxiosRequestConfig & {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -6,12 +6,15 @@ import ArrowBackIcon from '@/components/icons/system/ArrowBackIcon';
 import { useLogin } from '@/hooks/useAuth';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const LoginPage = () => {
   const navigate = useNavigate();
   const { t } = useTranslation(['headline', 'textField', 'buttonAction']);
   const { mutateAsync, isPending } = useLogin();
+  const [searchParam] = useSearchParams();
+
+  const redirectPath = searchParam.get('redirect');
 
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
@@ -35,7 +38,10 @@ const LoginPage = () => {
     <div className='flex flex-col items-center'>
       <AppBar
         LeadingIcon={ArrowBackIcon}
-        onLeadingIconClick={() => navigate(-1)}
+        onLeadingIconClick={() => {
+          if (redirectPath) navigate(redirectPath);
+          else navigate(-1);
+        }}
       />
 
       <Headline

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,22 +1,34 @@
 import { instance } from '@/lib/axios';
 import type { LoginRequest, LoginResponse } from '@/types/auth';
+import axios from 'axios';
 
 export const authApi = {
-  authentication: async () => {
-    const res = await instance.post('/api/v1/users/me');
+  verify: async () => {
+    const res = await instance.get('/api/v1/auth/verify');
 
     return res.data;
   },
+
   login: async (data: LoginRequest) => {
-    const res = await instance.post<LoginResponse>(
-      '/api/v1/auth/sign-in',
-      data
-    );
+    const res = await axios.post<LoginResponse>('/api/v1/auth/sign-in', data, {
+      withCredentials: true,
+    });
 
     return res.data;
   },
+
   logout: async () => {
     const res = await instance.post('/api/v1/auth/logout');
+
+    return res.data;
+  },
+
+  tokenRefresh: async () => {
+    const res = await axios.post(
+      '/api/v1/auth/refresh',
+      {},
+      { withCredentials: true }
+    );
 
     return res.data;
   },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,7 +13,7 @@ export interface LoginResponse extends ApiSuccessResponse {
 
 export interface AuthenticationResponse extends ApiSuccessResponse {
   data: {
-    grantType: string;
+    isTokenVerified: boolean;
   };
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     host: true,
     proxy: {
       '/api': {
-        target: 'https://clip-trip.shop',
+        target: 'https://api.clip-trip.shop',
         changeOrigin: true,
         secure: true,
       },


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 401발생 시 토큰 재발급 로직 구현
- 버그 수정:
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 토큰 만료 시 자동으로 재발급, 재 요청을 위해 구현
- 토큰 검증 api를 연동하여 라우트 보호 기능 구현

### 작업 내역 (bullet 으로 구분)

- 백엔드 proxy 주소 변경
- axios interceptors를 통해 401 오류 발생 시 자동 토큰 재발급 요청 및 이전 요청 retry기능 구현
- 만약 토큰 재발급 실패 시 로그인 페이지로 이동
- 로그인 페이지에서 redirect를 search param으로 받아 이전에 있던 페이지로 리다이렉트
- 토큰 검증 api를 통해 라우트 보호 기능 구현

### ?작업 후 기대 동작(스크린샷)

https://github.com/user-attachments/assets/575c722c-eb86-403c-a8cd-3fae3f1904de

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #51
