### PR TITLE
[Fix/issue-095] 토큰 재발급 로직 관련해서 재발급 실패 시 로그아웃 및 라우팅 기능 추가

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,6 +1,7 @@
 import { createTokenAxios } from '@jjjk0605/axios-token-refresh';
 import { useAuthStore } from '@/store/tokenStore';
 import type { TokenRefreshResponse } from '@/types/auth';
+import { authApi } from '@/services/authService';
 
 const baseURL = import.meta.env.VITE_BACKEND_URL;
 
@@ -21,4 +22,13 @@ export const { client: instance } = createTokenAxios({
   headerName: 'Authorization',
   headerScheme: 'Bearer ',
   shouldRefresh: (err) => err.response?.status === 401,
+  onRefreshFailure: async () => {
+    alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+    await authApi.logout();
+    useAuthStore.getState().setAccessToken(null);
+    const currentPath = window.location.pathname + window.location.search;
+    window.location.href = localStorage.getItem('language')
+      ? `/login?redirect=${encodeURIComponent(currentPath)}`
+      : '/onboarding';
+  },
 });


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 
- 버그 수정: 토큰 재발급 로직 관련해서 재발급 실패 시 로그아웃 및 라우팅 기능 추가
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 토큰 재발급이 실패할 경우(리프레쉬 토큰이 만료된 경우) 쿠키를 초기화시키고 로그아웃을 시켜야하는데 해당 로직이 빠져있었음

### 작업 내역 (bullet 으로 구분)

- createTokenAxios의 onRefreshFailure를 커스텀하여 로그인 만료시 동작을 설정
- 로그인 만료 시 로그아웃 및 라우팅 기능 추가

### ?작업 후 기대 동작(스크린샷)

- 동작

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #95


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토큰 새로고침 실패 시 사용자 경험을 개선했습니다. 인증 오류 발생 시 사용자를 자동으로 로그아웃하고 로그인 또는 온보딩 페이지로 리다이렉트합니다. 이전에는 오류가 조용히 무시되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->