### PR TITLE
[Feature/issue-099] 멱등키를 통해 비디오 분석의 멱등성을 보장, 새로고침 시에도 자동 재 요청

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
+    "uuid": "^13.0.0",
     "vaul": "^1.1.2",
     "zustand": "^5.0.6"
   },
@@ -64,11 +65,17 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "husky": "^9.1.7",
+    "msw": "^2.11.5",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tw-animate-css": "^1.3.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.11.5'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/components/common/FullPageLoading.tsx
+++ b/src/components/common/FullPageLoading.tsx
@@ -1,20 +1,23 @@
 import { createPortal } from 'react-dom';
 import Loading from '@/components/common/Loading';
 import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
 
 interface FullPageLoadingProps {
   className?: string;
+  children?: ReactNode;
 }
 
-const FullPageLoading = ({ className }: FullPageLoadingProps) => {
+const FullPageLoading = ({ className, children }: FullPageLoadingProps) => {
   return createPortal(
     <div
       className={cn(
-        'fixed inset-0 z-[9999] flex items-center justify-center bg-black/60',
+        'fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-black/60',
         className
       )}
     >
       <Loading />
+      {children}
     </div>,
     document.body
   );

--- a/src/components/pages/Home/UrlInput.tsx
+++ b/src/components/pages/Home/UrlInput.tsx
@@ -1,5 +1,4 @@
 import ButtonIcon from '@/components/common/ButtonIcon';
-import FullPageLoading from '@/components/common/FullPageLoading';
 import ArrowUpIcon from '@/components/icons/system/ArrowUpIcon';
 import { cn } from '@/lib/utils';
 import { useRef } from 'react';
@@ -21,7 +20,6 @@ const UrlInput = ({ onSearch, isPending }: UrlInputProps) => {
 
   return (
     <>
-      {isPending && <FullPageLoading />}
       <div className='bg-sy_container-neutral-normal rounded-016 h-fit w-[312px]'>
         <form
           onSubmit={handleSubmit}

--- a/src/hooks/useVideo.ts
+++ b/src/hooks/useVideo.ts
@@ -1,14 +1,45 @@
 import { videoApi } from '@/services/videoService';
 import type { ApiFailResponse } from '@/types/api';
 import type { VideosRequest, VideosResponse } from '@/types/video';
+import { getOrCreateIdempotencyKey } from '@/utils/idempotencyKey';
 import { useMutation } from '@tanstack/react-query';
+import type { AxiosResponse } from 'axios';
+import axios, { CanceledError } from 'axios';
 import { toast } from 'sonner';
 
+function isCanceled(err: unknown) {
+  return (
+    axios.isCancel?.(err)
+    || err instanceof CanceledError
+    || (err as Error)?.name === 'AbortError'
+  );
+}
+
+function isConflict409(error: unknown) {
+  return axios.isAxiosError(error) && error.response?.status === 409;
+}
+
 export const useVideos = () => {
-  return useMutation<VideosResponse, ApiFailResponse, VideosRequest>({
-    mutationFn: (data) => videoApi.youtube(data),
+  return useMutation<
+    AxiosResponse<VideosResponse>,
+    ApiFailResponse,
+    VideosRequest
+  >({
+    mutationFn: (data) => {
+      const idempotencyKey = getOrCreateIdempotencyKey(data);
+
+      return videoApi.youtube(data, idempotencyKey);
+    },
     onError: (error) => {
+      if (error instanceof Error && error.name === 'CanceledError') return;
       toast.error(error.message);
     },
+
+    retry: (_failureCount, error) => {
+      if (isCanceled(error)) return false;
+      return isConflict409(error);
+    },
+
+    retryDelay: () => 1000,
   });
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,16 +9,30 @@ import I18nProvider from '@/providers/I18nProvider.tsx';
 import { Toaster } from '@/components/ui/sonner.tsx';
 import { Analytics } from '@vercel/analytics/react';
 
+async function prepareApp() {
+  if (process.env.NODE_ENV === 'development') {
+    const { worker } = await import('./mocks/browser');
+
+    return worker.start({
+      onUnhandledRequest: 'bypass',
+    });
+  }
+
+  return Promise.resolve();
+}
+
 const queryClient = new QueryClient();
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <I18nProvider>
-        <App />
-        <Toaster />
-      </I18nProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <Analytics />
-    </QueryClientProvider>
-  </StrictMode>
-);
+prepareApp().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider>
+          <App />
+          <Toaster />
+        </I18nProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <Analytics />
+      </QueryClientProvider>
+    </StrictMode>
+  );
+});

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,59 @@
+import { http, HttpResponse } from 'msw';
+import { mockDb } from './state';
+import { mockVideoResponse } from './mockData'; // 실제 데이터 구조를 가진 모의 데이터
+
+export const handlers = [
+  // 1. 영상 분석 요청을 처리하는 POST 핸들러
+  http.post('/api/v1/videos', async ({ request }) => {
+    const idempotencyKey = request.headers.get('Idempotency-Key');
+    if (!idempotencyKey) return new HttpResponse(null, { status: 400 });
+
+    // Case 1: 새로운 작업일 때 (202 Accepted)
+    console.log(`[MSW] Mocking response: 202 Accepted (New Job)`);
+    mockDb.set(idempotencyKey, { status: 'PROCESSING' });
+
+    // 4초 뒤, '완료' 상태와 함께 모의 데이터를 저장
+    setTimeout(() => {
+      mockDb.set(idempotencyKey, {
+        status: 'COMPLETED',
+        result: mockVideoResponse,
+      });
+      console.log(mockDb);
+    }, 4000);
+
+    return HttpResponse.json({ jobId: idempotencyKey }, { status: 202 });
+  }),
+
+  // 2. SSE 연결을 처리하는 GET 핸들러
+  http.get('/api/analysis-events/:jobId', ({ params }) => {
+    const { jobId } = params;
+
+    const stream = new ReadableStream({
+      start(controller) {
+        console.log(`[MSW] SSE connection opened for job ${jobId}.`);
+
+        // 4초 뒤에 'completed' 이벤트와 함께 최종 데이터 전송
+        const intervalId = setInterval(() => {
+          if (mockDb.get(jobId as string)?.status !== 'COMPLETED') {
+            console.log(`[MSW] SSE processing...`);
+            return;
+          }
+
+          const completedData = mockDb.get(jobId as string)?.result;
+          const eventString = `event: completed\ndata: ${JSON.stringify(completedData || {})}\n\n`;
+          controller.enqueue(new TextEncoder().encode(eventString));
+          controller.close(); // 스트림 종료
+          console.log(`[MSW] SSE connection closed for job ${jobId}.`);
+          clearInterval(intervalId);
+        }, 1000);
+      },
+      cancel() {
+        console.log(`[MSW] SSE connection cancelled for job ${jobId}.`);
+      },
+    });
+
+    return new HttpResponse(stream, {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  }),
+];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -1,0 +1,67 @@
+import type { VideosResponse } from '@/types/video';
+
+export const mockVideoResponse: VideosResponse = {
+  httpStatusCode: 200,
+  message: '영상 분석 및 장소 추출에 성공했습니다.',
+  resultType: 'SUCCESS',
+
+  data: {
+    videoResponse: {
+      videoId: 101,
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      thumbnailUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hq720.jpg',
+      summary:
+        '이 영상은 서울의 맛집과 명소를 탐방하는 내용을 담고 있습니다. 첫 번째 장소인 광화문에서 시작하여, 유명한 한식당을 방문하고, 마지막으로 남산 타워의 야경을 즐기는 코스입니다.',
+    },
+    scheduleInfoResponse: {
+      id: 202,
+      name: '서울 미식 여행',
+      description:
+        '유튜브 영상 속 장소를 따라가는 하루짜리 서울 맛집 투어입니다.',
+      placeList: [
+        {
+          placeId: 301,
+          placeName: '토속촌 삼계탕',
+          roadAddress: '서울 종로구 자하문로5길 5',
+          phone: '02-737-7444',
+          type: 'RESTAURANT',
+          longitude: 126.9722,
+          latitude: 37.579,
+          translatedPlaceName: 'Tosokchon Samgyetang',
+          translatedRoadAddress: '5, Jahamun-ro 5-gil, Jongno-gu, Seoul',
+          language: 'KOREAN',
+          kakaoPlaceId: '8038896',
+          bookmarkedIdList: [1, 5, 12],
+        },
+        {
+          placeId: 302,
+          placeName: 'N서울타워',
+          roadAddress: '서울 용산구 남산공원길 105',
+          phone: '02-3455-9277',
+          type: 'TOURIST_ATTRACTION',
+          longitude: 126.9882,
+          latitude: 37.5512,
+          translatedPlaceName: 'N Seoul Tower',
+          translatedRoadAddress: '105, Namsangongwon-gil, Yongsan-gu, Seoul',
+          language: 'KOREAN',
+          kakaoPlaceId: '8038896',
+          bookmarkedIdList: [],
+        },
+        {
+          placeId: 303,
+          placeName: '스타벅스 경복궁역점',
+          roadAddress: '서울 종로구 사직로 130',
+          phone: '1522-3232',
+          type: 'CAFE',
+          longitude: 126.9734,
+          latitude: 37.5768,
+          translatedPlaceName: null,
+          translatedRoadAddress: null,
+          language: 'KOREAN',
+          kakaoPlaceId: '26569943',
+          bookmarkedIdList: [22],
+        },
+      ],
+    },
+  },
+};

--- a/src/mocks/state.ts
+++ b/src/mocks/state.ts
@@ -1,0 +1,8 @@
+import type { JsonBodyType } from 'msw';
+
+interface MockDbState {
+  status: 'PROCESSING' | 'COMPLETED';
+  result?: JsonBodyType;
+}
+
+export const mockDb = new Map<string, MockDbState>();

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,33 +1,92 @@
 import AppBar from '@/components/common/AppBar';
+import FullPageLoading from '@/components/common/FullPageLoading';
 import Headline from '@/components/common/Headline';
 import Navigation from '@/components/common/Navigation';
 import UrlInput from '@/components/pages/Home/UrlInput';
 import VideoDetail from '@/components/pages/Home/VideoDetail';
 import { useVideos } from '@/hooks/useVideo';
-import { useState } from 'react';
+import type { VideosResponse } from '@/types/video';
+import {
+  clearIdempotencyKey,
+  IDEMPOTENCY_KEY_BODY_STORAGE_KEY,
+  IDEMPOTENCY_KEY_STORAGE_KEY,
+} from '@/utils/idempotencyKey';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
 const Home = () => {
   const { t } = useTranslation(['appBar', 'headline']);
-  const [showVideoDetail, setShowVideoDetail] = useState(true);
-  const { mutateAsync, isPending, data: resData } = useVideos();
+  const [videoData, setVideoData] = useState<VideosResponse | null>(null);
+  const [analysisJobId, setAnalysisJobId] = useState<string | null>(null);
+  const { mutateAsync, isPending, reset } = useVideos();
 
-  const handleVideoSuccess = (success: boolean) => setShowVideoDetail(success);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const savedJobId = sessionStorage.getItem(IDEMPOTENCY_KEY_STORAGE_KEY);
+    if (savedJobId) {
+      setAnalysisJobId(savedJobId);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!analysisJobId) return;
+
+    const body = sessionStorage.getItem(IDEMPOTENCY_KEY_BODY_STORAGE_KEY);
+    if (body) {
+      handleSearch(JSON.parse(body).youtubeUrl);
+    }
+  }, [analysisJobId]);
 
   const handleSearch = async (url: string) => {
     if (isPending) return null;
 
-    await mutateAsync(
-      { youtubeUrl: url },
-      { onSuccess: () => handleVideoSuccess(true) }
-    );
+    abortControllerRef.current = new AbortController();
+
+    try {
+      const response = await mutateAsync({
+        youtubeUrl: url,
+        signal: abortControllerRef.current.signal,
+      });
+
+      if (response.status === 200) {
+        setVideoData(response.data);
+        setAnalysisJobId(null);
+        clearIdempotencyKey();
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.name === 'CanceledError') {
+          toast.info('분석 대기를 중단했습니다.');
+        } else {
+          toast.error('분석에 실패했습니다.');
+        }
+      } else {
+        toast.error('알 수 없는 오류가 발생했습니다.');
+      }
+
+      setAnalysisJobId(null);
+      clearIdempotencyKey();
+    }
   };
 
-  if (showVideoDetail && resData)
+  const handleCancelClientOnly = () => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    reset();
+
+    setAnalysisJobId(null);
+    clearIdempotencyKey();
+  };
+
+  if (videoData)
     return (
       <VideoDetail
-        data={resData.data}
-        onBack={() => handleVideoSuccess(false)}
+        data={videoData.data}
+        onBack={() => setVideoData(null)}
       />
     );
 
@@ -45,8 +104,23 @@ const Home = () => {
 
         <UrlInput
           onSearch={handleSearch}
-          isPending={isPending}
+          isPending={isPending || !!analysisJobId}
         />
+        {(isPending || !!analysisJobId) && (
+          <FullPageLoading>
+            <div className='text-center'>
+              <p className='text-white'>
+                분석 결과를 실시간으로 받아오는 중...
+              </p>
+              <button
+                onClick={handleCancelClientOnly}
+                className='mt-2 rounded bg-gray-500 px-4 py-2 text-white hover:bg-gray-600'
+              >
+                중단하기
+              </button>
+            </div>
+          </FullPageLoading>
+        )}
       </div>
 
       <Navigation className='fixed bottom-0' />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,6 +36,9 @@ const Home = () => {
     const body = sessionStorage.getItem(IDEMPOTENCY_KEY_BODY_STORAGE_KEY);
     if (body) {
       handleSearch(JSON.parse(body).youtubeUrl);
+    } else {
+      setAnalysisJobId(null);
+      clearIdempotencyKey();
     }
   }, [analysisJobId]);
 

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -2,9 +2,19 @@ import { instance } from '@/lib/axios';
 import type { VideosRequest } from '@/types/video';
 
 export const videoApi = {
-  youtube: async (data: VideosRequest) => {
-    const res = await instance.post('/api/v1/videos', data);
+  youtube: async (data: VideosRequest, idempotencyKey: string) => {
+    const res = await instance.post(
+      '/api/v1/videos',
+      { youtubeUrl: data.youtubeUrl },
+      {
+        headers: {
+          'Idempotency-Key': idempotencyKey,
+        },
+        signal: data.signal,
+        validateStatus: (status) => status >= 200 && status < 300,
+      }
+    );
 
-    return res.data;
+    return res;
   },
 };

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -4,6 +4,7 @@ import type { LanguageName } from '@/types/type';
 
 export interface VideosRequest {
   youtubeUrl: string;
+  signal: AbortSignal;
 }
 
 export interface VideosResponse extends ApiSuccessResponse {

--- a/src/utils/idempotencyKey.ts
+++ b/src/utils/idempotencyKey.ts
@@ -1,0 +1,24 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const IDEMPOTENCY_KEY_STORAGE_KEY = 'idempotencyKey';
+export const IDEMPOTENCY_KEY_BODY_STORAGE_KEY = 'idempotencyKey-body';
+
+export const getOrCreateIdempotencyKey = (body?: unknown) => {
+  let key = sessionStorage.getItem(IDEMPOTENCY_KEY_STORAGE_KEY);
+  if (!key) {
+    key = uuidv4();
+    sessionStorage.setItem(IDEMPOTENCY_KEY_STORAGE_KEY, key);
+    if (body) {
+      sessionStorage.setItem(
+        IDEMPOTENCY_KEY_BODY_STORAGE_KEY,
+        JSON.stringify(body)
+      );
+    }
+  }
+  return key;
+};
+
+export const clearIdempotencyKey = () => {
+  sessionStorage.removeItem(IDEMPOTENCY_KEY_STORAGE_KEY);
+  sessionStorage.removeItem(IDEMPOTENCY_KEY_BODY_STORAGE_KEY);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,43 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@inquirer/ansi@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-1.0.1.tgz#994f7dd16a00c547a7b110e04bf4f4eca1857929"
+  integrity sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==
+
+"@inquirer/confirm@^5.0.0":
+  version "5.1.19"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.19.tgz#bf28b420898999eb7479ab55623a3fbaf1453ff4"
+  integrity sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==
+  dependencies:
+    "@inquirer/core" "^10.3.0"
+    "@inquirer/type" "^3.0.9"
+
+"@inquirer/core@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-10.3.0.tgz#342e4fd62cbd33ea62089364274995dbec1f2ffe"
+  integrity sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==
+  dependencies:
+    "@inquirer/ansi" "^1.0.1"
+    "@inquirer/figures" "^1.0.14"
+    "@inquirer/type" "^3.0.9"
+    cli-width "^4.1.0"
+    mute-stream "^2.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^6.2.0"
+    yoctocolors-cjs "^2.1.2"
+
+"@inquirer/figures@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.14.tgz#12a7bfd344a83ae6cc5d6004b389ed11f6db6be4"
+  integrity sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==
+
+"@inquirer/type@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.9.tgz#f7f9696e9276e4e1ae9332767afb9199992e31d9"
+  integrity sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==
+
 "@isaacs/fs-minipass@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
@@ -675,6 +712,18 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@mswjs/interceptors@^0.39.1":
+  version "0.39.8"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.39.8.tgz#0a2cf4cf26a731214ca4156273121f67dff7ebf8"
+  integrity sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
@@ -704,6 +753,24 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
 "@radix-ui/number@1.1.1":
   version "1.1.1"
@@ -1369,6 +1436,11 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/statuses@^2.0.4":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.6.tgz#66748315cc9a96d63403baa8671b2c124f8633aa"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
+
 "@typescript-eslint/eslint-plugin@8.38.0":
   version "8.38.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz#6e5220d16f2691ab6d983c1737dd5b36e17641b7"
@@ -1645,6 +1717,11 @@ class-variance-authority@^0.7.1:
   dependencies:
     clsx "^2.1.1"
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -1730,7 +1807,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^1.0.1:
+cookie@^1.0.1, cookie@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
@@ -2259,6 +2336,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphql@^16.8.1:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -2282,6 +2364,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+headers-polyfill@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
+  integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
 
 html-parse-stringify@^3.0.1:
   version "3.0.1"
@@ -2364,6 +2451,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -2706,6 +2798,35 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^2.11.5:
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-2.11.5.tgz#69572ab70a60b5d72c8b6aed344595a7604241c0"
+  integrity sha512-atFI4GjKSJComxcigz273honh8h4j5zzpk5kwG4tGm0TPcYne6bqmVrufeRll6auBeouIkXqZYXxVbWSWxM3RA==
+  dependencies:
+    "@inquirer/confirm" "^5.0.0"
+    "@mswjs/interceptors" "^0.39.1"
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@types/statuses" "^2.0.4"
+    cookie "^1.0.2"
+    graphql "^16.8.1"
+    headers-polyfill "^4.0.2"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    rettime "^0.7.0"
+    statuses "^2.0.2"
+    strict-event-emitter "^0.5.1"
+    tough-cookie "^6.0.0"
+    type-fest "^4.26.1"
+    until-async "^3.0.2"
+    yargs "^17.7.2"
+
+mute-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
+  integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
+
 nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
@@ -2737,6 +2858,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -2797,6 +2923,11 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -2953,6 +3084,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+rettime@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rettime/-/rettime-0.7.0.tgz#c040f1a65e396eaa4b8346dd96ed937edc79d96f"
+  integrity sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==
+
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
@@ -3026,6 +3162,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 sonner@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.6.tgz#623b73faec55229d63ec35226d42021f2119bfa7"
@@ -3040,6 +3181,16 @@ split2@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
+statuses@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -3119,12 +3270,31 @@ tinyglobby@^0.2.14:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
+tldts-core@^7.0.17:
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.0.17.tgz#dadfee3750dd272ed219d7367beb7cbb2ff29eb8"
+  integrity sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==
+
+tldts@^7.0.5:
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.0.17.tgz#a6cdc067b9e80ea05f3be471c0ea410688cc78b2"
+  integrity sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==
+  dependencies:
+    tldts-core "^7.0.17"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tough-cookie@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.0.tgz#11e418b7864a2c0d874702bc8ce0f011261940e5"
+  integrity sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==
+  dependencies:
+    tldts "^7.0.5"
 
 ts-api-utils@^2.1.0:
   version "2.1.0"
@@ -3147,6 +3317,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^4.26.1:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 typescript-eslint@^8.35.1:
   version "8.38.0"
@@ -3172,6 +3347,11 @@ unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
+
+until-async@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/until-async/-/until-async-3.0.2.tgz#447f1531fdd7bb2b4c7a98869bdb1a4c2a23865f"
+  integrity sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==
 
 update-browserslist-db@^1.1.3:
   version "1.1.3"
@@ -3202,6 +3382,11 @@ use-sidecar@^1.1.3:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+uuid@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
+  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
 
 vaul@^1.1.2:
   version "1.1.2"
@@ -3241,6 +3426,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -3275,7 +3469,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.0.0:
+yargs@^17.0.0, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -3297,6 +3491,11 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+yoctocolors-cjs@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz#7e4964ea8ec422b7a40ac917d3a344cfd2304baa"
+  integrity sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==
 
 zustand@^5.0.6:
   version "5.0.7"


### PR DESCRIPTION
### 무엇을 위한 PR인가요? (: 뒤 설명 추가)

- 신규 기능 추가: 멱등키를 통해 비디오 분석의 멱등성을 보장, 새로고침 시에도 자동 재 요청
- 버그 수정:
- 리펙토링:
- 문서 업데이트:
- 기타:

### 변경사항 및 이유 (bullet 으로 구분)

- 이전에는 사용자가 시간이 오래 걸리는 비디오 분석 요청을 보낸 뒤, 새로고침을 하거나 네트워크가 유실된 경우 같은 요청을 보낼 때 새로 비디오를 분석하게 되어 리소스가 낭비되는 경우가 있었음
- 따라서 같은 요청에 대해서는 새로 분석 요청을 날리는 것이 아닌, 이전 분석 요청이 완료되기를 기다리거나 완료된 결과를 가져다 쓰도록 하여 리소스 낭비를 줄일 필요성이 생김

### 작업 내역 (bullet 으로 구분)

- 비디오 분석 요청을 보낼 때 header에 idempotency-Key를 담아서 요청을 전달
- 백엔드에서는 해당 key값이 db에 존재하는지 확인
- 존재하지 않을 경우 db에 해당 key값과 함께 PROCESSING상태를 등록 후 비디오 분석 시작
- 분석이 완료되면 200과 함께 결과 전달
- 존재한다면 해당 key값에 대응하는 응답 결과를 반환(분석이 완료되었다면 200, 진행중이라면 409)
- 프론트는 409가 반환될 시 1초마다 retry를 통해 결과를 기다림
- idempotency-Key값은 분석을 시작할때 프론트 측에서 body와 함께 sessionStorage에 저장
- 새로고침 시 sessionStorage를 확인하여 idempotency-Key값이 존재할 경우 해당 key와 body값을 통해 자동으로 요청을 재시도
- 중단하기 버튼을 통해 요청을 중간에 중단하는 기능도 존재

### ?작업 후 기대 동작(스크린샷)

- 비디오 분석 작업 도중 중단 가능
- 새로고침 시 이전 작업 이어가기 가능
- 리소스 낭비를 최소화

### ?PR 특이 사항

- 특이 사항

### Issue Number

close: #99 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발환경용 네트워크 모킹 도입(로컬에서 API 시뮬레이션 가능)
  * 분석 작업 복원(세션에 저장된 진행중 작업 자동 복구)

* **개선 사항**
  * 영상 분석 중 전면 로딩에 취소 버튼 추가(클라이언트 취소 지원)
  * 요청 취소 지원(진행중 요청 안전 종료)
  * 충돌(중복 요청)에 대한 자동 재시도 및 오류 피드백 개선

* **버그 수정**
  * 로딩 상태 및 UI 전환 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->